### PR TITLE
Broken link for HelloWorld project in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This library is currently a port of the WPF feature set. If you need to get supp
 
 ## How to use Uno with Prism
 
-To start a new Uno project with Prism support, take a look at [this](https://github.com/unoplatform/Uno.Prism/tree/master/Sandbox/Uno/HelloWorld) project.  
+To start a new Uno project with Prism support, take a look at [this](https://github.com/unoplatform/uno.Prism/tree/uno/Sandbox/Windows10/HelloWorld) project.  
 
 ## Contributing to Uno.Prism
 
-The main solution to use is [PrismLibrary_Uno.sln](Source/PrismLibrary_Uno.sln) with the included samples applications.
+The main solution to use is [PrismLibrary_Uno.sln](PrismLibrary_Uno.sln) with the included samples applications.
 ### E2E Build Status
 
 # Prism


### PR DESCRIPTION
﻿## Description of Change

This fixes the broken link for the "HelloWorld" sample project for Uno.Prism. This is now pointing to the project linked on the "Is there a Visual Studio template for Uno that incorporates the Prism library?" section in the [Uno Platform FAQ page](https://platform.uno/docs/articles/faq.html)

### Bugs Fixed

No actual bugs fixed other than the broken links.

### API Changes

No API changes.

### Behavioral Changes

No behavioral changes.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard